### PR TITLE
Make login_required decorator more lenient

### DIFF
--- a/source/osa5.html.erb
+++ b/source/osa5.html.erb
@@ -138,32 +138,21 @@ published: true
 # roles in login_required
 from functools import wraps
 
-def login_required(role="ANY"):
-    def wrapper(fn):
-        @wraps(fn)
+def login_required(_func=None, *, role="ANY"):
+    def wrapper(func):
+        @wraps(func)
         def decorated_view(*args, **kwargs):
-            if not current_user:
+            if not (current_user and current_user.is_authenticated):
                 return login_manager.unauthorized()
-          
-            if not current_user.is_authenticated:
-                return login_manager.unauthorized()
-            
-            unauthorized = False
 
-            if role != "ANY":
-                unauthorized = True
-                
-                for user_role in current_user.roles():
-                    if user_role == role:
-                        unauthorized = False
-                        break
+            acceptable_roles = set(("ANY", *current_user.roles()))
 
-            if unauthorized:
+            if role not in acceptable_roles:
                 return login_manager.unauthorized()
-            
-            return fn(*args, **kwargs)
+
+            return func(*args, **kwargs)
         return decorated_view
-    return wrapper
+    return wrapper if _func is None else wrapper(_func)
 <% end %>
 
 <p>


### PR DESCRIPTION
This pattern allows the usage of the `login_required`-decorator in all of the following ways:

    # No call
    @login_required
    def foo(*args, **kwargs):
        ...

    # Empty call (redundant)
    @login_required()
    def foo(*args, **kwargs):
        ...

    # Call with kwargs
    @login_required(role='FOO')
    def foo(*args, **kwargs):
        ...

While the implementation might seem more complex, the client usage should become more straightforward. As "no call" and "empty call" are now functionally equivalent, this hopefully reduces some confusion regarding when to use which version of the decorator function.